### PR TITLE
Fixa definição da pasta resources.

### DIFF
--- a/src/OpenBoleto/BoletoAbstract.php
+++ b/src/OpenBoleto/BoletoAbstract.php
@@ -259,7 +259,7 @@ abstract class BoletoAbstract
      * Pasta de localização de resources (imagens, css e views)
      * @var string
      */
-    protected $resourcePath = '../resources';
+    protected $resourcePath;
 
     /**
      * Localização do logotipo da empresa
@@ -280,6 +280,8 @@ abstract class BoletoAbstract
      */
     public function  __construct($params = array())
     {
+        $this->resourcePath = __DIR__ . '/../../resources';
+
         foreach ($params as $param => $value)
         {
             if (method_exists($this, 'set' . $param)) {


### PR DESCRIPTION
Daniel, fiz a instalação da sua lib através do composer e na hora de testar percebi que a definição da pasta resources estava incorreta, fiz esse fix com quase certeza que resolve todo tipo de uso.

Parabéns pela lib, está muito bem feita.
