### PR TITLE
Add CPF ao lado do sacado

### DIFF
--- a/resources/views/partials/ficha-de-compensacao.phtml
+++ b/resources/views/partials/ficha-de-compensacao.phtml
@@ -169,7 +169,7 @@
     <tr>
         <td colspan="7">
             <div class="titulo">Sacado</div>
-            <div class="conteudo"><?php echo $sacado ?></div>
+            <div class="conteudo"><?php echo $sacado; echo (isset($sacado_documento)) ? ' - ' . $sacado_documento : ''; ?></div>
             <div class="conteudo"><?php echo $sacado_endereco1 ?></div>
             <div class="conteudo"><?php echo $sacado_endereco2 ?></div>
 


### PR DESCRIPTION
Caso seja informado um CPF no construtor do Agente, será mostrado o CPF ao lado do nome do sacado, caso não seja informado nenhum CPF, mostrará apenas o sacado.