### PR TITLE
Alterando o valor base para o fator

### DIFF
--- a/src/OpenBoleto/Banco/Unicred.php
+++ b/src/OpenBoleto/Banco/Unicred.php
@@ -67,7 +67,7 @@ class Unicred extends BoletoAbstract
     protected function gerarNossoNumero()
     {
         $numero = self::zeroFill($this->getSequencial(), 10);
-        $dv = $this->modulo11($numero,7);
+        $dv = $this->modulo11($numero,9);
         $numero .= '-' . $dv['digito'];
 
         return $numero;


### PR DESCRIPTION
Na doc oficial do banco Unicred para emissão de boletos o número base para o cálculo do dígito verificador é 9 e não mais 7:

https://portal-api.e-unicred.com.br/api-portal/content/regra-nosso-numero