### PR TITLE
Corrige tag de UTF-8 para permitir uso com dompdf

### DIFF
--- a/resources/views/bancodobrasil.phtml
+++ b/resources/views/bancodobrasil.phtml
@@ -24,6 +24,7 @@
 <html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title><?php echo $cedente; ?></title>
     <style type="text/css">
         /* Embed the CSS content here */

--- a/resources/views/caixa.phtml
+++ b/resources/views/caixa.phtml
@@ -24,6 +24,7 @@
 <html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title><?php echo $cedente; ?></title>
     <style type="text/css">
         /* Embed the CSS content here */

--- a/resources/views/cecred.phtml
+++ b/resources/views/cecred.phtml
@@ -24,6 +24,7 @@
 <html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title><?php echo $cedente; ?></title>
     <style type="text/css">
         /* Embed the CSS content here */

--- a/resources/views/default-carne-sicoob.phtml
+++ b/resources/views/default-carne-sicoob.phtml
@@ -24,6 +24,7 @@
 <html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title><?php echo $cedente; ?></title>
     <style type="text/css">
         /* Embed the CSS content here */

--- a/resources/views/default-carne.phtml
+++ b/resources/views/default-carne.phtml
@@ -24,6 +24,7 @@
 <html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title><?php echo $cedente; ?></title>
     <style type="text/css">
         /* Embed the CSS content here */

--- a/resources/views/default-comprovante-entrega.phtml
+++ b/resources/views/default-comprovante-entrega.phtml
@@ -23,7 +23,8 @@
 -->
 <html lang="pt-BR">
     <head>
-        <meta charset="UTF-8">
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <title><?php echo $cedente; ?></title>
         <style type="text/css">
             /* Embed the CSS content here */

--- a/resources/views/default.phtml
+++ b/resources/views/default.phtml
@@ -24,6 +24,7 @@
 <html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title><?php echo $cedente; ?></title>
     <style type="text/css">
         /* Embed the CSS content here */

--- a/resources/views/safra.phtml
+++ b/resources/views/safra.phtml
@@ -24,6 +24,7 @@
 <html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title><?php echo $cedente; ?></title>
     <style type="text/css">
         /* Embed the CSS content here */


### PR DESCRIPTION
Esse ajuste permite conversão do html para pdf usando outras ferramentas como dompdf de forma que os caracteres sejam propriamente interpretados.

Sem a tag:
![image](https://user-images.githubusercontent.com/11444489/157260380-ede2d527-dc45-4f8e-9f15-7519715480f3.png)

Com a tag:
![image](https://user-images.githubusercontent.com/11444489/157260158-cdf9ac17-6d63-49fd-bda7-dc240c6b98f5.png)
