### PR TITLE
Pega o ano com base na data de emissao

### DIFF
--- a/src/OpenBoleto/Banco/Sicredi.php
+++ b/src/OpenBoleto/Banco/Sicredi.php
@@ -120,7 +120,6 @@ class Sicredi extends BoletoAbstract {
      * @return string
      */
     protected function gerarNossoNumero() {
-        // $ano = date("y");
         $ano = $this->dataDocumento->format('y');
 
         $numero = self::zeroFill($this->getAgencia(), 4) .

--- a/src/OpenBoleto/Banco/Sicredi.php
+++ b/src/OpenBoleto/Banco/Sicredi.php
@@ -120,7 +120,8 @@ class Sicredi extends BoletoAbstract {
      * @return string
      */
     protected function gerarNossoNumero() {
-        $ano = date("y");
+        // $ano = date("y");
+        $ano = $this->dataDocumento->format('y');
 
         $numero = self::zeroFill($this->getAgencia(), 4) .
                 self::zeroFill($this->getPosto(), 2) .


### PR DESCRIPTION
Para o calculo do nosso número , se o boleto foi emitido no ano anterior, pega o ano com base na data de emissao e nao com base na data atual