### PR TITLE
Aumentando nível do PHPStan

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 6
     paths:
         - src
         - tests

--- a/src/OpenBoleto/Agente.php
+++ b/src/OpenBoleto/Agente.php
@@ -92,6 +92,7 @@ class Agente
      * Define o CEP
      *
      * @param string $cep
+     * @return void
      */
     public function setCep($cep)
     {
@@ -112,6 +113,7 @@ class Agente
      * Define a cidade
      *
      * @param string $cidade
+     * @return void
      */
     public function setCidade($cidade)
     {
@@ -132,6 +134,7 @@ class Agente
      * Define o documento (CPF ou CNPJ)
      *
      * @param string $documento
+     * @return void
      */
     public function setDocumento($documento)
     {
@@ -152,6 +155,7 @@ class Agente
      * Define o endereço
      *
      * @param string $endereco
+     * @return void
      */
     public function setEndereco($endereco)
     {
@@ -172,6 +176,7 @@ class Agente
      * Define o nome
      *
      * @param string $nome
+     * @return void
      */
     public function setNome($nome)
     {
@@ -192,6 +197,7 @@ class Agente
      * Define a UF
      *
      * @param string $uf
+     * @return void
      */
     public function setUf($uf)
     {

--- a/src/OpenBoleto/Banco/Abc.php
+++ b/src/OpenBoleto/Banco/Abc.php
@@ -98,11 +98,18 @@ class Abc extends BoletoAbstract
         return $this;
     }
 
+    /**
+     * @param string|int $convenio
+     * @return void
+     */
     public function setConvenio($convenio)
     {
-        $this->convenio = $convenio;
+        $this->convenio = (string)$convenio;
     }
 
+    /**
+     * @return string
+     */
     public function getConvenio()
     {
         return $this->convenio;

--- a/src/OpenBoleto/Banco/BV.php
+++ b/src/OpenBoleto/Banco/BV.php
@@ -97,12 +97,19 @@ class BV extends BoletoAbstract
         $this->conta = self::zeroFill($conta, 9);
         return $this;
     }
-    
+
+    /**
+     * @param string|int $convenio
+     * @return void
+     */
     public function setConvenio($convenio)
     {
-        $this->convenio = $convenio;
+        $this->convenio = (string)$convenio;
     }
 
+    /**
+     * @return string
+     */
     public function getConvenio()
     {
         return $this->convenio;

--- a/src/OpenBoleto/Banco/Banese.php
+++ b/src/OpenBoleto/Banco/Banese.php
@@ -75,6 +75,10 @@ class Banese extends BoletoAbstract
         return $sequencial . '-' . $this->gerarDigitoVerificadorNossoNumero();
     }
 
+    /**
+     * @return int
+     * @throws \OpenBoleto\Exception
+     */
     protected function gerarDigitoVerificadorNossoNumero() {
         $sequencial = $this->getAgencia() . self::zeroFill($this->getSequencial(), 8);
         $digitoVerificador = static::modulo11($sequencial);
@@ -87,7 +91,7 @@ class Banese extends BoletoAbstract
      * 
      * (Cálculo do duplo dígito verificador da Chave ASBACE)
      * (BANESE_Manual_do_Bloqueto_BANESE_20061219.pdf - Página 7)
-     * 
+     * @param string $chave
      * @return string
      */
     protected function gerarDuploDigito($chave) {
@@ -96,7 +100,7 @@ class Banese extends BoletoAbstract
         $pesos = '21212121212121212121212';
         $somatorio = 0;
         for($indice = 0; $indice < 23; $indice++) {
-            $resultado = $chave[$indice] * $pesos[$indice];
+            $resultado = (int)$chave[$indice] * (int)$pesos[$indice];
             if($resultado > 9) {
                 $somatorio += ($resultado - 9);
             }

--- a/src/OpenBoleto/Banco/Banrisul.php
+++ b/src/OpenBoleto/Banco/Banrisul.php
@@ -74,8 +74,9 @@ class Banrisul extends BoletoAbstract
 
     /**
      * @param int $tipoCobranca
+     * @return void
      */
-    public function setTipoCobranca(int $tipoCobranca)
+    public function setTipoCobranca($tipoCobranca)
     {
         $this->tipoCobranca = $tipoCobranca;
     }

--- a/src/OpenBoleto/Banco/Cecred.php
+++ b/src/OpenBoleto/Banco/Cecred.php
@@ -148,6 +148,7 @@ class Cecred extends BoletoAbstract
     /**
      * Retorna o dígito verificador para o campo 1 conforme os padrões da CECRED
      *
+     * @param string $campo
      * @return int
      */
     protected function getDigitoVerificadorCampo1($campo)

--- a/src/OpenBoleto/Banco/HSBC.php
+++ b/src/OpenBoleto/Banco/HSBC.php
@@ -66,10 +66,12 @@ class HSBC extends BoletoAbstract
 
     /**
      * Calculo de Modulo 11 "Invertido" (com pesos de 9 a 2 e não de 2 a 9)
+     * @param string|int $num
      * @return int
      */
     protected function modulo11Invertido($num)
     {
+        $num = (string)$num;
         $ftini = 2;
         $ftfim = 9;
         $fator = $ftfim;
@@ -94,6 +96,7 @@ class HSBC extends BoletoAbstract
     /**
      * Gera o Nosso Número
      *
+     * @param bool $semDv
      * @return string
      */
     protected function gerarNossoNumero($semDv = false)

--- a/src/OpenBoleto/Banco/Itau.php
+++ b/src/OpenBoleto/Banco/Itau.php
@@ -137,6 +137,8 @@ class Itau extends BoletoAbstract
      * (sem DAC) / CARTEIRA / NOSSO NÚMERO”, calculado pelo critério do Módulo 10 (conforme Anexo 3).
      * À exceção, estão as carteiras 126 - 131 - 146 - 150 e 168 cuja obtenção está baseada apenas nos dados
      * “CARTEIRA/NOSSO NÚMERO” da operação
+     * 
+     * @return void
      */
     protected function gerarDacNossoNumero()
     {

--- a/src/OpenBoleto/Banco/Safra.php
+++ b/src/OpenBoleto/Banco/Safra.php
@@ -84,6 +84,10 @@ class Safra extends BoletoAbstract {
      * @var int
      */
     protected $carteiraDv;
+
+    /**
+     * @var string
+     */
     protected $campoLivre;
 
     /**
@@ -119,6 +123,10 @@ class Safra extends BoletoAbstract {
         return $numero;
     }
 
+    /**
+     * @return int
+     * @throws \OpenBoleto\Exception
+     */
     protected function gerarDigitoVerificadorNossoNumero() {
         $sequencial = self::zeroFill($this->getSequencial(), 8);
         $digitoVerificador = static::modulo11($sequencial);

--- a/src/OpenBoleto/Banco/Santander.php
+++ b/src/OpenBoleto/Banco/Santander.php
@@ -82,6 +82,7 @@ class Santander extends BoletoAbstract
      * Define o valor do IOS
      *
      * @param int $ios
+     * @return void
      */
     public function setIos($ios)
     {
@@ -109,6 +110,10 @@ class Santander extends BoletoAbstract
         return $sequencial . '-' . $this->gerarDigitoVerificadorNossoNumero();
     }
 
+    /**
+     * @return int
+     * @throws \OpenBoleto\Exception
+     */
     protected function gerarDigitoVerificadorNossoNumero() {
         $sequencial = self::zeroFill($this->getSequencial(), 12);
         $digitoVerificador = static::modulo11($sequencial);

--- a/src/OpenBoleto/Banco/Sicredi.php
+++ b/src/OpenBoleto/Banco/Sicredi.php
@@ -63,7 +63,7 @@ class Sicredi extends BoletoAbstract {
 
     /**
      * Campo obrigatório para emissão de boletos com carteira 198 fornecido pelo Banco com 5 dígitos
-     * @var int
+     * @var string
      */
     protected $codigoCliente;
 
@@ -78,13 +78,14 @@ class Sicredi extends BoletoAbstract {
      * @var int
      */
     protected $carteiraDv;
+
+    /**
+     * @var string
+     */
     protected $campoLivre;
 
     /**
-     * Define o código do cliente
-     *
-     * @param int $codigoCliente
-     * @return $this
+     * @var string
      */
     protected $posto;
 
@@ -100,15 +101,20 @@ class Sicredi extends BoletoAbstract {
      */
     protected $tipoCobranca = 3;
 
+    /**
+     * @param string|int $codigoCliente
+     * @return $this
+     */
     public function setCodigoCliente($codigoCliente) {
-        $this->codigoCliente = $codigoCliente;
+        $this->codigoCliente = (string)$codigoCliente;
+        
         return $this;
     }
 
     /**
      * Retorna o código do cliente
      *
-     * @return int
+     * @return string
      */
     public function getCodigoCliente() {
         return $this->codigoCliente;
@@ -186,7 +192,7 @@ class Sicredi extends BoletoAbstract {
     /**
      * Retorna o campo Posto do boleto
      *
-     * @return int
+     * @return string
      */
     public function getPosto() {
         return $this->posto;

--- a/src/OpenBoleto/BoletoAbstract.php
+++ b/src/OpenBoleto/BoletoAbstract.php
@@ -973,7 +973,7 @@ abstract class BoletoAbstract
     /**
      * Define o campo valor cobrado do boleto
      *
-     * @param  $valorCobrado
+     * @param float $valorCobrado
      * @return BoletoAbstract
      */
     public function setValorCobrado($valorCobrado)
@@ -995,7 +995,7 @@ abstract class BoletoAbstract
     /**
      * Define o campo "valor" do boleto
      *
-     * @param  $valorUnitario
+     * @param float $valorUnitario
      * @return BoletoAbstract
      */
     public function setValorUnitario($valorUnitario)
@@ -1170,6 +1170,7 @@ abstract class BoletoAbstract
      * Mostra exception ao erroneamente tentar setar o nosso número
      *
      * @throws Exception
+     * @return never-return
      */
     public final function setNossoNumero()
     {

--- a/tests/OpenBoleto/AgenteTest.php
+++ b/tests/OpenBoleto/AgenteTest.php
@@ -7,9 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 class AgenteTest extends TestCase
 {
+    /**
+     * @return void
+     */
     public function testInstantiationWithoutArgumentsShouldWork()
     {
         $instance = new Agente('nome','123.456.789-01');
-        $this->assertInstanceOf('OpenBoleto\Agente', $instance);
+        $this->assertInstanceOf(\OpenBoleto\Agente::class, $instance);
     }
 }

--- a/tests/OpenBoleto/Banco/BancoDoBrasilTest.php
+++ b/tests/OpenBoleto/Banco/BancoDoBrasilTest.php
@@ -7,11 +7,17 @@ use PHPUnit\Framework\TestCase;
 
 class BancoDoBrasilTest extends TestCase
 {
+    /**
+     * @return void
+     */
     public function testInstantiateWithoutArgumentsShouldWork()
     {
-        $this->assertInstanceOf('OpenBoleto\\Banco\\BancoDoBrasil', new BancoDoBrasil());
+        $this->assertInstanceOf(\OpenBoleto\Banco\BancoDoBrasil::class, new BancoDoBrasil());
     }
 
+    /**
+     * @return void
+     */
     public function testInstantiateWithConvenio7LengthShouldWork()
     {
         $instance = new BancoDoBrasil(array(
@@ -25,11 +31,14 @@ class BancoDoBrasilTest extends TestCase
             'convenio' => 1234567, // 4, 6 ou 7 dígitos
         ));
 
-        $this->assertInstanceOf('OpenBoleto\\Banco\\BancoDoBrasil', $instance);
+        $this->assertInstanceOf(\OpenBoleto\Banco\BancoDoBrasil::class, $instance);
         $this->assertEquals('00190.00009 01234.567004 00000.001180 7 55650000001050', $instance->getLinhaDigitavel());
         $this->assertSame('12345670000000001', (string) $instance->getNossoNumero());
     }
 
+    /**
+     * @return void
+     */
     public function testInstantiateWithConvenio6LengthShouldWork()
     {
         $instance = new BancoDoBrasil(array(
@@ -43,11 +52,14 @@ class BancoDoBrasilTest extends TestCase
             'convenio' => 123456, // 4, 6 ou 7 dígitos
         ));
 
-        $this->assertInstanceOf('OpenBoleto\\Banco\\BancoDoBrasil', $instance);
+        $this->assertInstanceOf(\OpenBoleto\Banco\BancoDoBrasil::class, $instance);
         $this->assertEquals('00191.23454 60000.115455 10403.005183 1 55650000001050', $instance->getLinhaDigitavel());
         $this->assertEquals('12345600001-7', $instance->getNossoNumero());
     }
 
+    /**
+     * @return void
+     */
     public function testInstantiateWithConvenio6LengthAndCarteira21ShouldWork()
     {
         $instance = new BancoDoBrasil(array(
@@ -61,11 +73,14 @@ class BancoDoBrasilTest extends TestCase
             'convenio' => 123456, // 4, 6 ou 7 dígitos
         ));
 
-        $this->assertInstanceOf('OpenBoleto\\Banco\\BancoDoBrasil', $instance);
+        $this->assertInstanceOf(\OpenBoleto\Banco\BancoDoBrasil::class, $instance);
         $this->assertEquals('00191.23454 61234.567891 01234.567210 6 55650000001050', $instance->getLinhaDigitavel());
         $this->assertSame('12345678901234567', (string) $instance->getNossoNumero());
     }
 
+    /**
+     * @return void
+     */
     public function testInstantiateWithConvenio4LengthShouldWork()
     {
         $instance = new BancoDoBrasil(array(
@@ -84,7 +99,7 @@ class BancoDoBrasilTest extends TestCase
             // Para isso, defina a carteira como 21 (mesmo sabendo que ela é 16 ou 17, isso é uma regra do banco)
         ));
 
-        $this->assertInstanceOf('OpenBoleto\\Banco\\BancoDoBrasil', $instance);
+        $this->assertInstanceOf(\OpenBoleto\Banco\BancoDoBrasil::class, $instance);
         $this->assertEquals('00191.23405 00000.115451 10403.005183 5 55650000001050', $instance->getLinhaDigitavel());
         $this->assertSame('12340000001-1', (string) $instance->getNossoNumero());
     }

--- a/tests/OpenBoleto/Banco/BradescoTest.php
+++ b/tests/OpenBoleto/Banco/BradescoTest.php
@@ -6,11 +6,17 @@ use PHPUnit\Framework\TestCase;
 
 class BradescoTest extends TestCase
 {
+    /**
+     * @return void
+     */
     public function testInstantiateWithoutArgumentsShouldWork()
     {
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Bradesco', new Bradesco());
+        $this->assertInstanceOf(\OpenBoleto\Banco\Bradesco::class, new Bradesco());
     }
 
+    /**
+     * @return void
+     */
     public function testInstantiateShouldWork()
     {
         $instance = new Bradesco(array(
@@ -23,7 +29,7 @@ class BradescoTest extends TestCase
             'conta' => 403005, // Até 7 dígitos
         ));
 
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Bradesco', $instance);
+        $this->assertInstanceOf(\OpenBoleto\Banco\Bradesco::class, $instance);
         $this->assertEquals('23791.17209 60012.345678 89040.300504 8 55650000001050', $instance->getLinhaDigitavel());
 
         $this->assertSame('00123456789', (string) $instance->getNossoNumero());

--- a/tests/OpenBoleto/Banco/BrbTest.php
+++ b/tests/OpenBoleto/Banco/BrbTest.php
@@ -7,11 +7,17 @@ use PHPUnit\Framework\TestCase;
 
 class BrbTest extends TestCase
 {
+    /**
+     * @return void
+     */
     public function testInstantiateWithoutArgumentsShouldWork()
     {
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Brb', new Brb());
+        $this->assertInstanceOf(\OpenBoleto\Banco\Brb::class, new Brb());
     }
 
+    /**
+     * @return void
+     */
     public function testInstantiateShouldWork()
     {
         $instance = new Brb(array(
@@ -24,7 +30,7 @@ class BrbTest extends TestCase
             'conta' => 0403005, // Até 7 dígitos
         ));
 
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Brb', $instance);
+        $this->assertInstanceOf(\OpenBoleto\Banco\Brb::class, $instance);
         $this->assertEquals('07090.00178 20132.613173 58964.070286 3 55650000001050', $instance->getLinhaDigitavel());
         $this->assertSame('175896407028', (string) $instance->getNossoNumero());
     }

--- a/tests/OpenBoleto/Banco/CaixaSICOBTest.php
+++ b/tests/OpenBoleto/Banco/CaixaSICOBTest.php
@@ -7,11 +7,17 @@ use PHPUnit\Framework\TestCase;
 
 class CaixaSICOBTest extends TestCase
 {
+    /**
+     * @return void
+     */
     public function testInstantiateWithoutArgumentsShouldWork()
     {
-        $this->assertInstanceOf('OpenBoleto\\Banco\\CaixaSICOB', new CaixaSICOB());
+        $this->assertInstanceOf(\OpenBoleto\Banco\CaixaSICOB::class, new CaixaSICOB());
     }
 
+    /**
+     * @return void
+     */
     public function testInstantiateShouldWork()
     {
         $instance = new CaixaSICOB(array(
@@ -23,7 +29,7 @@ class CaixaSICOBTest extends TestCase
             'conta' => '43375600001',
         ));
 
-        $this->assertInstanceOf('OpenBoleto\\Banco\\CaixaSICOB', $instance);
+        $this->assertInstanceOf(\OpenBoleto\Banco\CaixaSICOB::class, $instance);
         $this->assertEquals('10498.00020 88027.050140 33756.000015 7 65330000029494', $instance->getLinhaDigitavel());
         $this->assertSame('8000288027-8', (string) $instance->getNossoNumero());
     }

--- a/tests/OpenBoleto/Banco/CaixaTest.php
+++ b/tests/OpenBoleto/Banco/CaixaTest.php
@@ -6,11 +6,17 @@ use PHPUnit\Framework\TestCase;
 
 class CaixaTest extends TestCase
 {
+    /**
+     * @return void
+     */
     public function testInstantiateWithoutArgumentsShouldWork()
     {
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Caixa', new Caixa());
+        $this->assertInstanceOf(\OpenBoleto\Banco\Caixa::class, new Caixa());
     }
 
+    /**
+     * @return void
+     */
     public function testInstantiateShouldWork()
     {
         $instance = new Caixa(array(
@@ -22,7 +28,7 @@ class CaixaTest extends TestCase
             'conta' => '433756',
         ));
 
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Caixa', $instance);
+        $this->assertInstanceOf(\OpenBoleto\Banco\Caixa::class, $instance);
         $this->assertEquals('10494.33756 65000.200546 00000.006106 8 60060000081094', $instance->getLinhaDigitavel());
         $this->assertSame('24000005000000061-2', (string) $instance->getNossoNumero());
     }

--- a/tests/OpenBoleto/Banco/ItauTest.php
+++ b/tests/OpenBoleto/Banco/ItauTest.php
@@ -7,11 +7,17 @@ use PHPUnit\Framework\TestCase;
 
 class ItauTest extends TestCase
 {
+    /**
+     * @return void
+     */
     public function testInstantiateWithoutArgumentsShouldWork()
     {
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Itau', new Itau());
+        $this->assertInstanceOf(\OpenBoleto\Banco\Itau::class, new Itau());
     }
 
+    /**
+     * @return void
+     */
     public function testInstantiateShouldWork()
     {
         $instance = new Itau(array(
@@ -29,11 +35,14 @@ class ItauTest extends TestCase
             'numeroDocumento' => 1234567, // 7 dígitos
         ));
 
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Itau', $instance);
+        $this->assertInstanceOf(\OpenBoleto\Banco\Itau::class, $instance);
         $this->assertEquals('34191.12127 34567.881726 41234.580003 1 55650000001050', $instance->getLinhaDigitavel());
         $this->assertSame('112/12345678-8', (string) $instance->getNossoNumero());
     }
 
+    /**
+     * @return void
+     */
     public function testInstantiateWithCarteira107ShouldWork()
     {
         $instance = new Itau(array(
@@ -51,7 +60,7 @@ class ItauTest extends TestCase
             'numeroDocumento' => 1234567, // 7 dígitos
         ));
 
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Itau', $instance);
+        $this->assertInstanceOf(\OpenBoleto\Banco\Itau::class, $instance);
         $this->assertEquals('34191.07127 34567.812341 56766.677001 9 55650000001050', $instance->getLinhaDigitavel());
         $this->assertSame('107/12345678-8', (string) $instance->getNossoNumero());
     }

--- a/tests/OpenBoleto/Banco/SantanderTest.php
+++ b/tests/OpenBoleto/Banco/SantanderTest.php
@@ -7,11 +7,17 @@ use PHPUnit\Framework\TestCase;
 
 class SantanderTest extends TestCase
 {
+    /**
+     * @return void
+     */
     public function testInstantiateWithoutArgumentsShouldWork()
     {
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Santander', new Santander());
+        $this->assertInstanceOf(\OpenBoleto\Banco\Santander::class, new Santander());
     }
 
+    /**
+     * @return void
+     */
     public function testInstantiateShouldWork()
     {
         $instance = new Santander(array(
@@ -27,7 +33,7 @@ class SantanderTest extends TestCase
             'ios' => '0', // Apenas para o Santander
         ));
 
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Santander', $instance);
+        $this->assertInstanceOf(\OpenBoleto\Banco\Santander::class, $instance);
         $this->assertEquals('03399.12347 56701.234561 78901.001020 2 55650000002300', $instance->getLinhaDigitavel()); 
         $this->assertSame('012345678901-0', (string) $instance->getNossoNumero());
     }

--- a/tests/OpenBoleto/Banco/SicoobTest.php
+++ b/tests/OpenBoleto/Banco/SicoobTest.php
@@ -6,11 +6,17 @@ use PHPUnit\Framework\TestCase;
 
 class SicoobTest extends TestCase
 {
+    /**
+     * @return void
+     */
     public function testInstantiateWithoutArgumentsShouldWork()
     {
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Sicoob', new Sicoob());
+        $this->assertInstanceOf(\OpenBoleto\Banco\Sicoob::class, new Sicoob());
     }
 
+    /**
+     * @return void
+     */
     public function testInstantiateShouldWork()
     {
         $instance = new Sicoob(array(
@@ -26,7 +32,7 @@ class SicoobTest extends TestCase
             'sequencial' => '203210', // Até 10 dígitos
         ));
 
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Sicoob', $instance);        
+        $this->assertInstanceOf(\OpenBoleto\Banco\Sicoob::class, $instance);        
         $this->assertEquals('75691.30698 01015.385006 20321.010017 9 75350000157575', $instance->getLinhaDigitavel());
 
         $this->assertSame('0203210-1', (string) $instance->getNossoNumero());

--- a/tests/OpenBoleto/Banco/UnicredTest.php
+++ b/tests/OpenBoleto/Banco/UnicredTest.php
@@ -6,11 +6,17 @@ use PHPUnit\Framework\TestCase;
 
 class UnicredTest extends TestCase
 {
+    /**
+     * @return void
+     */
     public function testInstantiateWithoutArgumentsShouldWork()
     {
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Unicred', new Unicred());
+        $this->assertInstanceOf(\OpenBoleto\Banco\Unicred::class, new Unicred());
     }
 
+    /**
+     * @return void
+     */
     public function testInstantiateShouldWork()
     {
         $instance = new Unicred(array(
@@ -23,7 +29,7 @@ class UnicredTest extends TestCase
             'sequencial' => 13951, // Até 10 dígitos
         ));
 
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Unicred', $instance);
+        $this->assertInstanceOf(\OpenBoleto\Banco\Unicred::class, $instance);
         $this->assertEquals('13693.30202 00000.225904 00001.395136 9 55650000001050', $instance->getLinhaDigitavel());
         $this->assertSame('0000013951-3', (string) $instance->getNossoNumero());
     }

--- a/tests/OpenBoleto/Banco/UniprimeTest.php
+++ b/tests/OpenBoleto/Banco/UniprimeTest.php
@@ -6,11 +6,17 @@ use PHPUnit\Framework\TestCase;
 
 class UniprimeTest extends TestCase
 {
+    /**
+     * @return void
+     */
     public function testInstantiateWithoutArgumentsShouldWork()
     {
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Uniprime', new Uniprime());
+        $this->assertInstanceOf(\OpenBoleto\Banco\Uniprime::class, new Uniprime());
     }
 
+    /**
+     * @return void
+     */
     public function testInstantiateShouldWork()
     {
         $instance = new Uniprime(array(
@@ -26,7 +32,7 @@ class UniprimeTest extends TestCase
             'convenio' => 1234567, // 4, 6 ou 7 dígitos
         ));
 
-        $this->assertInstanceOf('OpenBoleto\\Banco\\Uniprime', $instance);
+        $this->assertInstanceOf(\OpenBoleto\Banco\Uniprime::class, $instance);
         $this->assertEquals('08491.17205 90012.345675 89040.300504 3 55650000001050', $instance->getLinhaDigitavel());
 
         $this->assertSame('00123456789', (string) $instance->getNossoNumero());

--- a/tests/OpenBoleto/BoletoAbstractTest.php
+++ b/tests/OpenBoleto/BoletoAbstractTest.php
@@ -7,32 +7,44 @@ use PHPUnit\Framework\TestCase;
 
 class BoletoAbstractTest extends TestCase
 {
+    /**
+     * @return void
+     */
     public function testInstantiateShouldSetDefaultResourcePath()
     {
         $bank = new BancoMock();
         $this->assertTrue(file_exists($bank->getResourcePath()));
     }
-    
+
+    /**
+     * @return void
+     */
     public function testShouldReturnUserResourcePathIfPassed()
     {
         $bank = new BancoMock(array('resourcePath' => __DIR__));
         $this->assertEquals(__DIR__, $bank->getResourcePath());
     }
 
+    /**
+     * @return void
+     */
     public function testInvalidCarteiraExceptionsShouldBeThrown()
     {
-        $this->expectException('OpenBoleto\\Exception');
+        $this->expectException(\OpenBoleto\Exception::class);
         new BancoMock(array(
             'carteira' => 99,
         ));
     }
 
+    /**
+     * @return void
+     */
     public function testValidCarteiraShouldWork()
     {
         $instance = new BancoMock(array(
             'carteira' => 10,
         ));
 
-        $this->assertInstanceOf('OpenBoleto\BoletoAbstract', $instance);
+        $this->assertInstanceOf(\OpenBoleto\BoletoAbstract::class, $instance);
     }
 }

--- a/tests/OpenBoleto/FactoryTest.php
+++ b/tests/OpenBoleto/FactoryTest.php
@@ -6,27 +6,35 @@ use PHPUnit\Framework\TestCase;
 
 class FactoryTest extends TestCase
 {
+    /**
+     * @return void
+     * @throws \OpenBoleto\Exception
+     */
     public function testWhetherLoadByBankIdReturnsTheRightInstance()
     {
-        $this->assertInstanceOf('OpenBoleto\Banco\BancoDoBrasil', BoletoFactory::loadByBankId(1));
-        $this->assertInstanceOf('OpenBoleto\Banco\Santander', BoletoFactory::loadByBankId(33));
-        $this->assertInstanceOf('OpenBoleto\Banco\Brb', BoletoFactory::loadByBankId(70));
-        $this->assertInstanceOf('OpenBoleto\Banco\Unicred', BoletoFactory::loadByBankId(90));
-        $this->assertInstanceOf('OpenBoleto\Banco\Bradesco', BoletoFactory::loadByBankId(237));
-        $this->assertInstanceOf('OpenBoleto\Banco\Itau', BoletoFactory::loadByBankId(341));
-        $this->assertInstanceOf('OpenBoleto\Banco\Caixa', BoletoFactory::loadByBankId(104));
-        $this->assertInstanceOf('OpenBoleto\Banco\Uniprime', BoletoFactory::loadByBankId(84));
+        $this->assertInstanceOf(\OpenBoleto\Banco\BancoDoBrasil::class, BoletoFactory::loadByBankId(1));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Santander::class, BoletoFactory::loadByBankId(33));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Brb::class, BoletoFactory::loadByBankId(70));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Unicred::class, BoletoFactory::loadByBankId(90));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Bradesco::class, BoletoFactory::loadByBankId(237));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Itau::class, BoletoFactory::loadByBankId(341));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Caixa::class, BoletoFactory::loadByBankId(104));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Uniprime::class, BoletoFactory::loadByBankId(84));
     }
 
+    /**
+     * @return void
+     * @throws \OpenBoleto\Exception
+     */
     public function testWhetherLoadByBankNameReturnsTheRightInstance()
     {
-        $this->assertInstanceOf('OpenBoleto\Banco\BancoDoBrasil', BoletoFactory::loadByBankName('BancoDoBrasil'));
-        $this->assertInstanceOf('OpenBoleto\Banco\Santander', BoletoFactory::loadByBankName('Santander'));
-        $this->assertInstanceOf('OpenBoleto\Banco\Brb', BoletoFactory::loadByBankName('Brb'));
-        $this->assertInstanceOf('OpenBoleto\Banco\Unicred', BoletoFactory::loadByBankName('Unicred'));
-        $this->assertInstanceOf('OpenBoleto\Banco\Bradesco', BoletoFactory::loadByBankName('Bradesco'));
-        $this->assertInstanceOf('OpenBoleto\Banco\Itau', BoletoFactory::loadByBankName('Itau'));
-        $this->assertInstanceOf('OpenBoleto\Banco\Caixa', BoletoFactory::loadByBankName('Caixa'));
-        $this->assertInstanceOf('OpenBoleto\Banco\Uniprime', BoletoFactory::loadByBankName('Uniprime'));
+        $this->assertInstanceOf(\OpenBoleto\Banco\BancoDoBrasil::class, BoletoFactory::loadByBankName('BancoDoBrasil'));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Santander::class, BoletoFactory::loadByBankName('Santander'));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Brb::class, BoletoFactory::loadByBankName('Brb'));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Unicred::class, BoletoFactory::loadByBankName('Unicred'));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Bradesco::class, BoletoFactory::loadByBankName('Bradesco'));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Itau::class, BoletoFactory::loadByBankName('Itau'));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Caixa::class, BoletoFactory::loadByBankName('Caixa'));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Uniprime::class, BoletoFactory::loadByBankName('Uniprime'));
     }
 }


### PR DESCRIPTION
No nível 6 passa a ser obrigatório informar o tipo de retorno dos métodos.
Corrigi os que não estavam especificados.
Também passei a adotar FQCN nos nomes de classes, pois assim ao renomear uma classe no PHPStorm por exemplo, ele já renomeia todas as referências nos testes automatizados.