### PR TITLE
Ajuste no  calculo do fator de vencimento

### DIFF
--- a/src/BoletoAbstract.php
+++ b/src/BoletoAbstract.php
@@ -1551,19 +1551,27 @@ abstract class BoletoAbstract
     }
 
     /**
-     * Retorna o número de dias de 07/10/1997 até a data de vencimento do boleto
+     * Retorna o número de dias de 07/10/1997 até a data de vencimento do boleto, 
+     * caso a data de vencimento seja posterior a 21/02/2025 será usado 21/02/2025
      * Ou 0000 caso não tenha data de vencimento (contra-apresentação)
      *
      * @return string
      */
     protected function getFatorVencimento()
     {
-        if (!$this->getContraApresentacao()) {
-            $date = new DateTime('1997-10-07');
-            return (string) $date->diff($this->getDataVencimento())->days;
-        } else {
+        if ($this->getContraApresentacao()) {
             return '0000';
         }
+        
+        $dataVencimento = $this->getDataVencimento();
+
+        $date = new DateTime('2025-02-21');
+        if ($dataVencimento > $date) {
+            return (string) $date->diff($dataVencimento)->days + '1000';
+        }
+
+        $date = new DateTime('1997-10-07');
+        return (string) $date->diff($dataVencimento)->days;
     }
 
     /**


### PR DESCRIPTION
Ajustado calculo do fator de vencimento, para reiniciar a contagem do fator de vencimento quando a data de vencimento do boleto for superior a 21/02/2025.

Conforme manual Bradesco:
https://banco.bradesco/assets/pessoajuridica/pdf/MPO-Troca-Arquivos-Layout-240P.pdf
![image](https://github.com/openboleto/openboleto/assets/24395717/dc03e104-68b6-4508-b10c-5c2d72a66789)
