### PR TITLE
Ajuste no  calculo do fator de vencimento

### DIFF
--- a/src/BoletoAbstract.php
+++ b/src/BoletoAbstract.php
@@ -1565,8 +1565,8 @@ abstract class BoletoAbstract
         
         $dataVencimento = $this->getDataVencimento();
 
-        $date = new DateTime('2025-02-21');
-        if ($dataVencimento > $date) {
+        $date = new DateTime('2025-02-22');
+        if ($dataVencimento >= $date) {
             return (string) $date->diff($dataVencimento)->days + '1000';
         }
 


### PR DESCRIPTION
Verificado detalhe no ajuste anterior,  estava calculando com um dia a mais.


Agora o calculo está de acordo, conforme verificado no manual :
https://www.bb.com.br/docs/pub/emp/empl/dwn/Doc5175Bloqueto.pdf

![image](https://github.com/openboleto/openboleto/assets/24395717/e7f5865b-cebe-4edf-b229-6f270c52fb3d)
