### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+.editorconfig          export-ignore
+.gitattributes         export-ignore
+/.github/              export-ignore
+/bootstrap_phpunit.php export-ignore
+/docs/                 export-ignore
+/phpstan-baseline.neon export-ignore
+/phpstan.neon          export-ignore
+/phpunit.xml           export-ignore
+/samples/              export-ignore
+/tests/                export-ignore


### PR DESCRIPTION
Adiciona o arquivo .gitattributes com configurações específicas para otimizar o processo de exportação do código (ao adicionar a dependencia), excluindo arquivos e diretórios que não são necessários em ambientes de produção. Garantindo que apenas arquivos necessários para execução em produção sejam incluídos.

closses #209