### PR TITLE
fix: suporte ao banco unicred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,8 @@ v2.0.0
 
 * Início versionamento do projeto
 * Ajustado o cálculo do Fator de Vencimento, que estava concatenando o valor ao invés de somar
+
+v2.0.1
+===================
+
+* Fix: Foi realizada a correção no código do banco Unicred, que estava configurado como 90, sendo que o código correto é 136. #223

--- a/src/BoletoFactory.php
+++ b/src/BoletoFactory.php
@@ -51,8 +51,9 @@ class BoletoFactory
         33 => 'Santander',
         41 => 'Banrisul',
         70 => 'Brb',
-        90 => 'Unicred',
+        //90 => 'Unicred', /** TODO Código 90 não implementado */
         104 => 'Caixa',
+        136 => 'Unicred',
         237 => 'Bradesco',
         341 => 'Itau',
         399 => 'HSBC',

--- a/src/BoletoFactory.php
+++ b/src/BoletoFactory.php
@@ -51,7 +51,7 @@ class BoletoFactory
         33 => 'Santander',
         41 => 'Banrisul',
         70 => 'Brb',
-        //90 => 'Unicred', /** TODO Código 90 não implementado */
+        90 => 'Unicred', /** Mantido por compatibilidade */
         104 => 'Caixa',
         136 => 'Unicred',
         237 => 'Bradesco',

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -16,11 +16,12 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(\OpenBoleto\Banco\BancoDoBrasil::class, BoletoFactory::loadByBankId(1));
         $this->assertInstanceOf(\OpenBoleto\Banco\Santander::class, BoletoFactory::loadByBankId(33));
         $this->assertInstanceOf(\OpenBoleto\Banco\Brb::class, BoletoFactory::loadByBankId(70));
-        $this->assertInstanceOf(\OpenBoleto\Banco\Unicred::class, BoletoFactory::loadByBankId(136));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Unicred::class, BoletoFactory::loadByBankId(90));
         $this->assertInstanceOf(\OpenBoleto\Banco\Bradesco::class, BoletoFactory::loadByBankId(237));
         $this->assertInstanceOf(\OpenBoleto\Banco\Itau::class, BoletoFactory::loadByBankId(341));
         $this->assertInstanceOf(\OpenBoleto\Banco\Caixa::class, BoletoFactory::loadByBankId(104));
         $this->assertInstanceOf(\OpenBoleto\Banco\Uniprime::class, BoletoFactory::loadByBankId(84));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Unicred::class, BoletoFactory::loadByBankId(136));
     }
 
     /**

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -16,7 +16,7 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(\OpenBoleto\Banco\BancoDoBrasil::class, BoletoFactory::loadByBankId(1));
         $this->assertInstanceOf(\OpenBoleto\Banco\Santander::class, BoletoFactory::loadByBankId(33));
         $this->assertInstanceOf(\OpenBoleto\Banco\Brb::class, BoletoFactory::loadByBankId(70));
-        $this->assertInstanceOf(\OpenBoleto\Banco\Unicred::class, BoletoFactory::loadByBankId(90));
+        $this->assertInstanceOf(\OpenBoleto\Banco\Unicred::class, BoletoFactory::loadByBankId(136));
         $this->assertInstanceOf(\OpenBoleto\Banco\Bradesco::class, BoletoFactory::loadByBankId(237));
         $this->assertInstanceOf(\OpenBoleto\Banco\Itau::class, BoletoFactory::loadByBankId(341));
         $this->assertInstanceOf(\OpenBoleto\Banco\Caixa::class, BoletoFactory::loadByBankId(104));


### PR DESCRIPTION
Foi realizada a correção no código do banco **Unicred**, que estava configurado como **90**, sendo que o código correto é **136**.

O código **90** corresponde à **Cooperativa Central de Crédito do Estado de SP** que nem deve existir mais ou é outro banco agora, que ainda não foi implementada.

Única referencia que encontrei sobre o código 90:
[Referência código 90](https://www.cartaobndes.gov.br/cartaobndes/paginascartao/PopUpGenerico.asp?Papel=1&Classe=Fornecedor&Titulo=Lista+de+Bancos&Acao=AFILLB&Cod=1546325&)

Nas listas atualizadas não é possível mais encontrar esse código 90.

![implementados](https://github.com/user-attachments/assets/ec60f690-c318-4906-b211-6bdc6fff9ca7)
