### PR TITLE
Remover propriedade static da logo do banco

### DIFF
--- a/src/BoletoAbstract.php
+++ b/src/BoletoAbstract.php
@@ -1159,13 +1159,9 @@ abstract class BoletoAbstract
      */
     public function getLogoBancoBase64()
     {
-        static $logoData;
-
-        $logoData or $logoData = 'data:image/' . pathinfo($this->getLogoBanco(), PATHINFO_EXTENSION) .
+        return 'data:image/' . pathinfo($this->getLogoBanco(), PATHINFO_EXTENSION) .
             ';base64,' . base64_encode(file_get_contents($this->getResourcePath() .
                 '/images/' . $this->getLogoBanco()));
-
-        return $logoData;
     }
 
     /**


### PR DESCRIPTION
Para contexto, estou criando um serviço que dispara emails com boletos de diversos bancos.
Por causa da propriedade static na variável `$logoData`, a logo do primeiro banco gerado persiste para os outros boletos, o que causa a impressão que todos os boletos são do mesmo banco, mesmo não sendo.

A solução mais simples que encontrei e resolveu pra mim, foi justamente remover essa propriedade static, não reparei nenhum problema após a alteração.

Para replicar o problema é bem simples, basta gerar vários boletos de diferentes bancos na mesma página:
> Nesse exemplo, todas as logos serão do Sicoob.

```php
<?php

require '../autoloader.php';

use OpenBoleto\Banco\Bradesco;
use OpenBoleto\Banco\Sicoob;
use OpenBoleto\Banco\Unicred;
use OpenBoleto\Agente;
use OpenBoleto\BoletoAbstract;

$sacado = new Agente('Fernando Maia', '023.434.234-34', 'ABC 302 Bloco N', '72000-000', 'Brasília', 'DF');
$cedente = new Agente('Empresa de cosméticos LTDA', '02.123.123/0001-11', 'CLS 403 Lj 23', '71000-000', 'Brasília', 'DF');

$boleto = new Sicoob([
  // dados do boleto
]);

echo $boleto->getOutput();

$boleto = new Unicred([
  // dados do boleto
]
);

echo $boleto->getOutput();

$boleto = new Bradesco([
  // dados do boleto
]);

echo $boleto->getOutput();
```